### PR TITLE
fix writing pickled-compressed-base64-encoded data

### DIFF
--- a/bin/thermo_extract_cutsom_headers.py
+++ b/bin/thermo_extract_cutsom_headers.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 
     # zlib and pickle all the data
     for k, v in data_dict.items():
-        data_dict[k] = base64.b64encode(zlib.compress(pickle.dumps(v), level=9))
+        data_dict[k] = base64.b64encode(zlib.compress(pickle.dumps(v), level=9)).decode("utf-8")
 
     # Write Output
     with open(args.out_csv, "w") as csv_out:


### PR DESCRIPTION
Fix issue when writing the CSV files. `base64.b64encode()` returns bytes. When adding them to CSV, Python uses the bytes representation rather then converting it to string, ultimately the value in the CSV is `b'<THE_INTENDED_BASE64_STR>'` instead of `<THE_INTENDED_BASE64_STR>`.   
By reading the created file, the value contains `b'` & `'` at beginning and end (tried using `csv` & `pandas`) making it impossible to use decoded/uncompress/unpicke it without a small workaround.