### PR TITLE
fix error when procesing non ISA files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -86,12 +86,21 @@ workflow {
 
 
 	// // Concatenate to large csv
-	combined_csvs = get_various_mzml_infos.out.collect().concat(
-		retrieve_spikeins.out.collect(),
-		get_features.out.map { it[1] }.collect(),
-		execute_pia.out[1].collect(),
-		get_custom_headers.out.collect()
-	).collect()
+	combined_csvs = get_various_mzml_infos.out.collect()
+	if (params.main_is_isa) {
+		combined_csvs = combined_csvs.concat(
+			retrieve_spikeins.out.collect(),
+			get_features.out.map { it[1] }.collect(),
+			execute_pia.out[1].collect(),
+			get_custom_headers.out.collect()
+		).collect()
+	} else {
+		combined_csvs = combined_csvs.concat(
+			get_features.out.map { it[1] }.collect(),
+			execute_pia.out[1].collect(),
+			get_custom_headers.out.collect()
+		).collect()
+	}
 	combine_output_to_table(combined_csvs)
 	
 


### PR DESCRIPTION
Running the workflow with `--main_is_isa false` returned error `Access to 'retrieve_spikeins.out' is undefined since the workflow 'retrieve_spikeins' has not been invoked before accessing the output attribute` as `retrieve_spikeins` is only executed with `--main_is_isa true`.   
I added a simple if-statement to get around this issue but the spike in colums are missing in the `quality_control.csv`. Does it introduce any issue in the future for the analysis or visualization?  
It is not ideal for the databse insertion but not a real drama.