### PR TITLE
Added Support for mzML Input only

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -44,12 +44,14 @@ params.rt_unit = "sec" // Unit of the retention time, either sec for seconds or 
 params.output_column_order = "''" // Order of columns in the output table
 params.spikein_columns = "Maximum_Intensity,RT_at_Maximum_Intensity,PSMs,Delta_to_expected_RT" // Columns of the spike-in dataframes that should end up in the result table
 params.output_table_type = "csv" // Type of the output table, either csv or xlsx
+
 params.height_barplots = 700 // Height of the barplots in pixels
 params.width_barplots = 0 // Width of the barplots in pixels, 0 = flexible width
 params.height_pca = 1000 // Height of the PCA plot in pixels
 params.width_pca = 1000 // Width of the PCA plot in pixels
 params.height_ionmaps = 10 // Height of the ion maps in inches
 params.width_ionmaps = 10 // Width of the ion maps in inches
+
 
 // Here are some optional Parameters which can be set if needed
 params.search_spike_ins = true // Parameter to check if we execute a isa specific xic extraction (NOTE: FASTA has to contain the SpikeIns too!)
@@ -77,13 +79,13 @@ params.ms_run_metrics__bruker_headers = ""
 workflow {
 	if (params.visualize_only) { 		 // only visualization
 		list_hdf5_files = file(params.main_input_folder + '/*.hdf5')
-		visualization(list_hdf5_files, params.main_outdir, params.rt_unit, params.output_column_order, params.spikein_columns, params.output_table_type, params.search_spike_ins)
+		visualization(list_hdf5_files, params.main_outdir, params.rt_unit, params.output_column_order, params.spikein_columns, params.output_table_type, params.search_spike_ins, params.height_barplots, params.width_barplots, params.height_pca, params.width_pca, params.height_ionmaps, params.width_ionmaps)
 	}
 	else { // whole workflow execution
 		// Retrieve input files
-		thermo_raw_files = Channel.fromPath(params.main_raw_spectra_folder + "/*.raw")
-		bruker_raw_folders = Channel.fromPath(params.main_raw_spectra_folder + "/*.d", type: 'dir')
-		input_mzml_files = Channel.fromPath(params.main_raw_spectra_folder + "/*.mzML")
+		thermo_raw_files = Channel.fromPath(params.main_input_folder + "/*.raw")
+		bruker_raw_folders = Channel.fromPath(params.main_input_folder + "/*.d", type: 'dir')
+		input_mzml_files = Channel.fromPath(params.main_input_folder + "/*.mzML")
 
 		main_outdir = Channel.fromPath(params.main_outdir).first()
 
@@ -92,7 +94,7 @@ workflow {
 		fasta_file = Channel.fromPath(params.main_fasta_file).first()
 		mcquac_params_file = Channel.fromPath(params.mcquac_params_file).first()
 
-		raw_files = thermo_raw_files.concat(bruker_raw_folders)
+		spectra_files = thermo_raw_files.concat(bruker_raw_folders)
 
 		// File conversion into open formats
 		coverted_mzmls = convert_raws_to_mzml(thermo_raw_files, bruker_raw_folders)
@@ -133,7 +135,7 @@ workflow {
 				psm_results = pia_report_psm_mztabs
 			}
 
-			spike_in_metrics = retrieve_spike_ins_information(raw_files, psm_results, spike_ins_table)
+			spike_in_metrics = retrieve_spike_ins_information(spectra_files, psm_results, spike_ins_table)
 		}
 			
 		// Run Feature Finding
@@ -159,11 +161,9 @@ workflow {
 		combined_metrics = combine_metric_hdf5(hdf5s_per_run, main_outdir)
 
 		// Visualize the results (and move them to the results folder)
-		visualization(combined_metrics, params.main_outdir, params.rt_unit, params.output_column_order, params.spikein_columns, params.output_table_type, params.search_spike_ins, 
-			params.height_barplots, params.width_barplots, params.height_pca, params.width_pca, params.height_ionmaps, params.width_ionmaps)
+		visualization(combined_metrics, params.main_outdir, params.rt_unit, params.output_column_order, params.spikein_columns, params.output_table_type, params.search_spike_ins, params.height_barplots, params.width_barplots, params.height_pca, params.width_pca, params.height_ionmaps, params.width_ionmaps)
 
-		output_processing_success(raw_files.concat(input_mzml_files), hdf5s_per_run.toList().transpose().first().flatten())
+		output_processing_success(spectra_files.concat(input_mzml_files), hdf5s_per_run.toList().transpose().first().flatten())
 
 	}
 }
-

--- a/src/visualization.nf
+++ b/src/visualization.nf
@@ -17,9 +17,15 @@ workflow visualization {
         spikein_columns
         output_table_type
         search_spike_ins
+        height_barplots
+        width_barplots
+        height_pca
+        width_pca
+        height_ionmaps
+        width_ionmaps
 
     main:
-        visualize_results(combined_metrics, main_outdir, rt_unit, output_column_order, spikein_columns, output_table_type, search_spike_ins)
+        visualize_results(combined_metrics, main_outdir, rt_unit, output_column_order, spikein_columns, output_table_type, search_spike_ins, height_barplots, width_barplots, height_pca, width_pca, height_ionmaps, width_ionmaps)
 
     emit:
         visualize_results.out[0]
@@ -43,8 +49,12 @@ process visualize_results {
     val spikein_columns
     val output_table_type
     val search_spike_ins
-
-
+    val height_barplots
+    val width_barplots
+    val height_pca
+    val width_pca
+    val height_ionmaps
+    val width_ionmaps
 
     output:
     path("*.json")
@@ -58,9 +68,9 @@ process visualize_results {
     """
     if ${search_spike_ins}
     then 
-    QC_visualization.py -hdf5_files ${combined_metrics} -output "." -spikeins -RT_unit ${rt_unit} -output_column_order ${output_column_order} -spikein_columns ${spikein_columns} -output_table_type ${output_table_type}
+    QC_visualization.py -hdf5_files ${combined_metrics} -output "." -spikeins -RT_unit ${rt_unit} -output_column_order ${output_column_order} -spikein_columns ${spikein_columns} -output_table_type ${output_table_type} -height_barplots ${height_barplots} -width_barplots ${width_barplots} -height_pca ${height_pca} -width_pca ${width_pca} -height_ionmaps ${height_ionmaps} -width_ionmaps ${width_ionmaps}
     else
-    QC_visualization.py -hdf5_files ${combined_metrics} -output "." -RT_unit ${rt_unit} -output_column_order ${output_column_order} -spikein_columns ${spikein_columns} -output_table_type ${output_table_type}
+    QC_visualization.py -hdf5_files ${combined_metrics} -output "." -RT_unit ${rt_unit} -output_column_order ${output_column_order} -spikein_columns ${spikein_columns} -output_table_type ${output_table_type} -height_barplots ${height_barplots} -width_barplots ${width_barplots} -height_pca ${height_pca} -width_pca ${width_pca} -height_ionmaps ${height_ionmaps} -width_ionmaps ${width_ionmaps}
     fi
     """
 }


### PR DESCRIPTION
This just works, as our HDF5 combination just uses all available information, concatenating them into a single file if available.

This could also be interesting for adding hdf5-files into the input folder, something like: *.raw and already McQuac-result *.hdf5 in the input folder. We then only need to do the following: 

1. Retrieve available hdf5s here (just like mzML) : https://github.com/mpc-bioinformatics/McQuaC/blob/e56b86af71292fa769f21d0c21df5911d124e997/main.nf#L53
2. Do a `.concat`, to add the already processed hdf5s into the visualization generation here: https://github.com/mpc-bioinformatics/McQuaC/blob/e56b86af71292fa769f21d0c21df5911d124e997/main.nf#L124


Would this be of interest to have a "generic input-folder" allowing `.raw`. `.d`, `.mzML` and `.hdf5` and using them as much as we can? 

---

This workflow runs with only mzML-input, however the visualization is broken, since it expects some outputs

---

Fixes #117 and #107