### PR TITLE
add feature_list extracted from the hdf5 and fill in some missing des…

### DIFF
--- a/bin/QC_visualization.py
+++ b/bin/QC_visualization.py
@@ -316,7 +316,6 @@ def argparse_setup():
 
 if __name__ == "__main__":
     args = argparse_setup()
-    print(args)
 
     args.hdf5_files = sorted(args.hdf5_files) # sorts the file names alphabetically (assumes that they are all in the same folder)
 
@@ -424,10 +423,45 @@ if __name__ == "__main__":
     if args.output_table_type == "csv":
         df_table0.to_csv(output_path + os.sep + "00_table_summary.csv", index = False)
     if args.output_table_type == "tsv":   
-        df_table0.to_csv(output_path + os.sep + "00_table_summary.csv", index = False, sep = "\t")
+        df_table0.to_csv(output_path + os.sep + "00_table_summary.tsv", index = False, sep = "\t")
     if args.output_table_type == "xlsx":
         df_table0.to_excel(output_path + os.sep + "00_table_summary.xlsx", index = False)   
     
+################################################################################################
+    # hdf5 feature list: table containing all features of the hdf5 files and their descriptions
+    
+    key_list = []
+    hdf5_feature_list = []
+    for hdf in hdf5s:
+        key_list_tmp = list(hdf.keys())
+        ## check if there are additional keys in the hdf5 file that are not in the previous files:
+        key_list_diff = set(key_list_tmp).difference(set(key_list))
+        key_list = set(key_list).union(set(key_list_tmp))
+        if not len(key_list_diff) == 0:
+            hdf5_feature_list_tmp = []
+            for key in key_list_diff:
+                D = hdf[key]
+                hdf5_feature_list_tmp.append({
+                    'key': key,
+                    'qc_description': D.attrs.get('qc_description', ''),
+                    'qc_name': D.attrs.get('qc_name', ''),
+                    'qc_short_name': D.attrs.get('qc_short_name', ''),
+                    'unit_accession': D.attrs.get('unit_accession', ''),
+                    'unit_name': D.attrs.get('unit_name', '')
+                })
+            hdf5_feature_list.append(pd.DataFrame(hdf5_feature_list_tmp))
+
+    hdf5_feature_table = pd.concat(hdf5_feature_list, ignore_index=True)
+    ## sort by key alphabetically
+    hdf5_feature_table = hdf5_feature_table.sort_values(by = "key", ascending=True)
+
+    if args.output_table_type == "csv":
+        hdf5_feature_table.to_csv(output_path + os.sep + "99_hdf5_feature_table.csv", index = False)
+    if args.output_table_type == "tsv":   
+        hdf5_feature_table.to_csv(output_path + os.sep + "99_hdf5_feature_table.tsv", index = False, sep = "\t")
+    if args.output_table_type == "xlsx":
+        hdf5_feature_table.to_excel(output_path + os.sep + "99_hdf5_feature_table.xlsx", index = False)   
+
 
 ################################################################################################
     # Figure 01: Barplot for total number of MS1 and MS2 spectra
@@ -1220,7 +1254,6 @@ if __name__ == "__main__":
             
             df_tmp = df_calibrants[df_calibrants["calibrant_mz"] == row["calibrant_mz"]]
             df_tmp = df_tmp[df_tmp["calibrant_mobility"] == row["calibrant_mobility"]]
-            print(df_tmp)
             
             mz_tmp = row["calibrant_mz"]
             mobility_tmp = row["calibrant_mobility"]

--- a/bin/extract_from_pia_output.py
+++ b/bin/extract_from_pia_output.py
@@ -190,7 +190,9 @@ def parse_psm_infos(pia_psm_mztab: str, out_hdf5: h5py.File, store_all_infos: bo
                       "UO:0000189", "count unit")
     
     add_table_to_hdf5(out_hdf5,
-                      "Local:09", "PSM_charge_fractions", "TODO", "TODO", 
+                      "Local:09", "PSM_charge_fractions", 
+                      "fractions of precursor charge states of the PSMs", 
+                      "Precursor charge states of the PSMs as fractions (only identifications are counted, not all precursors).", 
                       ["1", "2", "3", "4", "5", "6 or more"], charge_fractions, ["float64", "float64", "float64", "float64", "float64", "float64"]
     )
 
@@ -200,9 +202,14 @@ def parse_psm_infos(pia_psm_mztab: str, out_hdf5: h5py.File, store_all_infos: bo
     )
 
     add_entry_to_hdf5(out_hdf5,
-                      "LOCAL:05", "filtered_psms_ppm_error", "deviations in PPM for each PSM", "TODO", 
-                      ppm_error, (len(ppm_error),), "float64", 
-                      "UO:0000169", "parts per million")
+                        "LOCAL:05", "filtered_psms_ppm_error", "deviations in PPM for each PSM", 
+                            "Expected and calculated mass-to-charge ratios are compared for each PSM. Results are given in parts per million (ppm).",
+                       # {
+                       #     "Expected and calculated mass-to-charge ratios are compared for each PSM. "
+                       #     "Results are given in parts per million (ppm)."
+                       # }, 
+                        ppm_error, (len(ppm_error),), "float64", 
+                        "UO:0000169", "parts per million")
     
     if store_all_infos and (unfiltered_psms is not None):
         # TODO: fix in PIA

--- a/bin/extract_from_pia_output.py
+++ b/bin/extract_from_pia_output.py
@@ -117,7 +117,7 @@ def parse_protein_infos(pia_proteins_mztab: str, out_hdf5: h5py.File):
                       "UO:0000189", "count unit")
     
     add_entry_to_hdf5(out_hdf5,
-                      "Local:08", "nr_accessions", "number of identified protein accessions", "All protein accessions within the protein groups are counted (ungreouped protein groups).", 
+                      "LOCAL:08", "nr_accessions", "number of identified protein accessions", "All protein accessions within the protein groups are counted (ungreouped protein groups).", 
                       number_ungrouped_proteins, (1,), "int32", 
                       "UO:0000189", "count unit")
 
@@ -190,7 +190,7 @@ def parse_psm_infos(pia_psm_mztab: str, out_hdf5: h5py.File, store_all_infos: bo
                       "UO:0000189", "count unit")
     
     add_table_to_hdf5(out_hdf5,
-                      "Local:09", "PSM_charge_fractions", 
+                      "LOCAL:09", "PSM_charge_fractions", 
                       "fractions of precursor charge states of the PSMs", 
                       "Precursor charge states of the PSMs as fractions (only identifications are counted, not all precursors).", 
                       ["1", "2", "3", "4", "5", "6 or more"], charge_fractions, ["float64", "float64", "float64", "float64", "float64", "float64"]

--- a/bin/extract_spike_metrics.py
+++ b/bin/extract_spike_metrics.py
@@ -161,6 +161,7 @@ if __name__ == "__main__":
             (
                 "Table of various spike-ins metrics like, "
                 "max. intensity, RT at max. intensity, PSMs, and delta to expected RT."
+                " RT_at_Maximum_Intensity defaults to -1 if the spike-in was not found."
             ),
             column_names,
             column_data,


### PR DESCRIPTION
I added the export of a feature list from hdf5. It basically just grabs all attributes inside the hdf5 and stores them in a table. If the different hdf5 files have different sets of keys (e.g. if files from different machines are mixed), it will use the union of all keys.

Addionally, I filled in some missing descriptions for the hdf5 keys that I saw when testing the feature list.

This should solve the issues #116 as well as #90 (NA = -1 mentioned in description now)