### PR TITLE
allow pre-filtering for FDR on PSM level in PIA

### DIFF
--- a/bin/adjust_comet_params.py
+++ b/bin/adjust_comet_params.py
@@ -49,6 +49,11 @@ if __name__ == "__main__":
                 line = "output_mzidentmlfile = 1"
             elif line.startswith("output_percolatorfile"):      # disable percolator output
                 line = "output_percolatorfile = 0"
+            elif line.startswith("max_duplicate_proteins"):     # export all proteins per PSM
+                line = "max_duplicate_proteins = -1"
+            elif line.startswith("equal_I_and_L"):              # I and L are not equal for us here
+                line = "equal_I_and_L = 0"
+
             # now set the variable search parameters
             elif line.startswith("peptide_mass_tolerance_upper"):      
                 line = f"peptide_mass_tolerance_upper = {args.peptide_mass_tolerance_upper}"

--- a/main.nf
+++ b/main.nf
@@ -107,7 +107,7 @@ workflow {
 				.transpose()
 				.first()
 				.flatten()
-		pia_extract_csv = pia_extract_metrics(pia_report_files)
+		pia_extract_csv = pia_extract_metrics(pia_report_files, params.identification__peptides_table, params.main_outdir)
 
 		// search additionally for labelled PSMs
 		if (params.search_labelled_spikeins) {

--- a/main.nf
+++ b/main.nf
@@ -99,6 +99,7 @@ workflow {
 			comet_ids.mzids,
 			params.identification__pia_threads,
 			params.identification__pia_gb_ram,
+			params.identification__pia_fdr_threshold,
 			params.identification__pia_prefilter
 		)
 		pia_report_psm_mztabs = pia_report_files
@@ -134,7 +135,8 @@ workflow {
 				comet_labelled_ids.mzids,
 				false,
 				params.identification__pia_threads,
-				params.identification__pia_gb_ram
+				params.identification__pia_gb_ram,
+				params.identification__pia_fdr_threshold
 			)
 	}
 

--- a/main.nf
+++ b/main.nf
@@ -98,7 +98,8 @@ workflow {
 		pia_report_files = pia_analysis_full(
 			comet_ids.mzids,
 			params.identification__pia_threads,
-			params.identification__pia_gb_ram
+			params.identification__pia_gb_ram,
+			params.identification__pia_prefilter
 		)
 		pia_report_psm_mztabs = pia_report_files
 				.toList()

--- a/main.nf
+++ b/main.nf
@@ -103,9 +103,9 @@ workflow {
 		)
 		pia_report_psm_mztabs = pia_report_files
 				.toList()
-					.transpose()
-					.first()
-					.flatten()
+				.transpose()
+				.first()
+				.flatten()
 		pia_extract_csv = pia_extract_metrics(pia_report_files)
 
 		// search additionally for labelled PSMs

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,6 +64,7 @@ params {
   identification__pia_gb_ram = 16
   identification__pia_fdr_threshold = 0.01
   identification__pia_prefilter = 0.05
+  identification__peptides_table = false
 }
 
 manifest {

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,7 +51,7 @@ params {
   identification__comet_mem = "10.GB"
   identification__generate_decoys = true
   identification__store_decoy_fasta = false
-  identification__decoy_method = "shuffle"
+  identification__decoy_method = "reverse"
   identification__peptide_mass_tolerance_upper = 5.0
   identification__peptide_mass_tolerance_lower = -5.0
   identification__peptide_mass_units = 2
@@ -112,7 +112,7 @@ profiles {
 
     process {
       withLabel: pia_image {
-        container = "quay.io/biocontainers/pia:1.5.6--hdfd78af_0"
+        container = "quay.io/biocontainers/pia:1.5.7--hdfd78af_0"
       }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,7 @@ params {
   identification__label_modifications = "add_K_lysine = 8.014199;add_R_arginine = 10.008269"
   identification__pia_threads = 8
   identification__pia_gb_ram = 16
+  identification__pia_prefilter = 0.05
 }
 
 manifest {

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,7 @@ params {
   identification__label_modifications = "add_K_lysine = 8.014199;add_R_arginine = 10.008269"
   identification__pia_threads = 8
   identification__pia_gb_ram = 16
+  identification__pia_fdr_threshold = 0.01
   identification__pia_prefilter = 0.05
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -262,7 +262,7 @@
           "type": "string",
           "description": "Applied method for the generation of decoys, either \"reverse\" or \"shuffle\"",
           "enum": ["reverse", "shuffle"],
-          "default": "shuffle"
+          "default": "reverse"
         },
         "identification__peptide_mass_tolerance_upper": {
           "type": "number",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -327,8 +327,8 @@
         "identification__pia_prefilter": {
           "type": "number",
           "default": 0.05,
-          "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering.",
-          "minimum": 0.03
+          "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering. Set negative to disable pre-filtering.",
+          "maximum": 1
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -324,10 +324,18 @@
           "description": "Allowed RAM to be used by PIA, in GB",
           "minimum": 4
         },
+        "identification__pia_fdr_threshold": {
+          "type": "number",
+          "default": 0.01,
+          "description": "The FDR threshold used for filtering PSMs by PIA, typically set to 0.01 (1%).",
+          "minimum": 0,
+          "maximum": 1
+        },
         "identification__pia_prefilter": {
           "type": "number",
           "default": 0.05,
-          "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering. Set negative to disable pre-filtering.",
+          "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering. Set to 0 to disable pre-filtering.",
+          "minimum": 0,
           "maximum": 1
         }
       }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -337,6 +337,11 @@
           "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering. Set to 0 to disable pre-filtering.",
           "minimum": 0,
           "maximum": 1
+        },
+        "identification__peptides_table": {
+          "type": "boolean",
+          "default": false,
+          "description": "If this is true, for each analysed MS run one peptide table will be exported."
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -323,6 +323,12 @@
           "default": 16,
           "description": "Allowed RAM to be used by PIA, in GB",
           "minimum": 4
+        },
+        "identification__pia_prefilter": {
+          "type": "number",
+          "default": 0.05,
+          "description": "Perform pre-filtering on PSM level before protein and peptide inference in PIA, use this threshold for pre-filtering.",
+          "minimum": 0.03
         }
       }
     }

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -221,6 +221,7 @@ process prepare_analysis_json {
 
     sed -i 's;"createPSMsets": .*,;"createPSMsets": false,;g' pia_analysis.json
     sed -i 's;"psmLevelFileID": .*,;"psmLevelFileID": 1,;g' pia_analysis.json
+    sed -i 's;"topIdentifications": .*,;"topIdentifications": 1,;g' pia_analysis.json
     sed -i 's;"calculateCombinedFDRScore": .*,;"calculateCombinedFDRScore": false,;g' pia_analysis.json
     if [ ${psm_export} = true ];
     then

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -45,7 +45,7 @@ workflow pia_analysis {
         pia_all_report_files = pia_run_analysis(basename_to_pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
 
         // TODO: remove this ugly hack! implement basenames and results further downstream correctly!
-        pia_all_report_files = pia_rename_files_HOTFIX_CHANGE(pia_all_report_files)
+        pia_all_report_files = pia_rename_files_HOTFIX_CHANGE(pia_all_report_files.psms, pia_all_report_files.peptides, pia_all_report_files.proteins)
 
         return_files = pia_all_report_files.psms.collect()
             .concat(pia_all_report_files.peptides.collect())
@@ -156,7 +156,7 @@ workflow perform_pia_prefiltering {
         prefiltered_pia_xmls = compile_pia_xmls(pia_prefiltered.psms, pia_threads, pia_gb_ram)
 
     emit:
-    prefiltered_pia_xmls
+        prefiltered_pia_xmls
 }
 
 
@@ -211,7 +211,7 @@ process prepare_analysis_json {
     """
     pia --example > pia_analysis.json
     
-    # delete the first row of the file, which contains en explanatory comment and does not start with the json
+    # delete the first row of the file, which contains an explanatory comment and does not start with the json
     sed -i 1d pia_analysis.json
 
     sed -i 's;"createPSMsets": .*,;"createPSMsets": false,;g' pia_analysis.json
@@ -291,9 +291,9 @@ process pia_run_analysis {
     val psm_export_format               // needs to be set correctly for pre-processing (mzid) and final (mzTab) 
 
     output:
-    tuple val({search_basename}), path("psms.${psm_export_format}"), emit: psms
-    tuple val({search_basename}), path("peptides.csv"), emit: peptides
-    tuple val({search_basename}), path("proteins.mzTab"), emit: proteins
+    tuple val(search_basename), path("psms.${psm_export_format}"), emit: psms
+    tuple val(search_basename), path("peptides.csv"), emit: peptides
+    tuple val(search_basename), path("proteins.mzTab"), emit: proteins
 
     script:
     """

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -46,7 +46,7 @@ workflow pia_analysis {
         pia_all_report_files = pia_run_analysis(basename_to_pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
 
         // TODO: remove this ugly hack! implement basenames and results further downstream correctly!
-        pia_all_report_files = pia_rename_files_HOTFIX_CHANGE(pia_all_report_files.psms, pia_all_report_files.peptides, pia_all_report_files.proteins)
+        pia_all_report_files = pia_rename_files(pia_all_report_files.psms, pia_all_report_files.peptides, pia_all_report_files.proteins)
 
         return_files = pia_all_report_files.psms.collect()
             .concat(pia_all_report_files.peptides.collect())
@@ -343,7 +343,7 @@ process pia_extract_csv {
 //
 // TODO: GET RID OF THIS PROCESS and implement the file and basenames correctly further downstream
 //
-process pia_rename_files_HOTFIX_CHANGE {
+process pia_rename_files {
     label 'mcquac_image'
 
     cpus 1

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -25,15 +25,27 @@ workflow pia_analysis {
         pia_prefilter_threshold
 
     main:
-        pia_xmls = compile_pia_xmls(identifications, pia_threads, pia_gb_ram)
+        basename_to_ids = identifications.map { it -> 
+            tuple(
+                it.baseName,
+                it
+            )
+        }
+        basename_to_pia_xmls = compile_pia_xmls(basename_to_ids, pia_threads, pia_gb_ram)
 
         if (pia_prefilter_threshold > 0) {
             // perform the pre-filtering
-            pia_xmls = perform_pia_prefiltering(pia_xmls, pia_prefilter_threshold, pia_threads, pia_gb_ram)
+            basename_to_pia_xmls = perform_pia_prefiltering(basename_to_pia_xmls, pia_prefilter_threshold, pia_threads, pia_gb_ram)
         }
 
-        analysis_json = prepare_analysis_json(do_psm_export, do_peptide_export, do_protein_export, fdr_filter, true, 0.01)
-        pia_all_report_files = pia_run_analysis(pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
+        analysis_json = prepare_analysis_json(do_psm_export, do_peptide_export, do_protein_export, fdr_filter,
+                true,      // remove_decoys
+                0.01       // fdr_threshold, hardcoded to 1% for now
+        )
+        pia_all_report_files = pia_run_analysis(basename_to_pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
+
+        // TODO: remove this ugly hack! implement basenames and results further downstream correctly!
+        pia_all_report_files = pia_rename_files_HOTFIX_CHANGE(pia_all_report_files)
 
         return_files = pia_all_report_files.psms.collect()
             .concat(pia_all_report_files.peptides.collect())
@@ -95,7 +107,7 @@ workflow pia_analysis_psm_only {
             fdr_filter,
             pia_threads,
             pia_gb_ram,
-            -1
+            -1                  // <0 -> no pre-filtering here
         )
 
     emit:
@@ -125,15 +137,22 @@ workflow pia_extract_metrics {
 
 workflow perform_pia_prefiltering {
     take:
-        pia_xmls
+        basename_to_pia_xmls
         pia_prefilter_threshold
         pia_threads
         pia_gb_ram
 
     main:
         // perform the pre-filtering
-        prefilter_analysis_json = prepare_analysis_json(true, false, false, true, false, pia_prefilter_threshold)
-        pia_prefiltered = pia_run_analysis(pia_xmls, prefilter_analysis_json, pia_threads, pia_gb_ram, "mzid")
+        prefilter_analysis_json = prepare_analysis_json(
+            true,  // psm_export
+            false, // peptide_export
+            false, // protein_export
+            true,  // fdr_filter
+            false, // remove_decoys
+            pia_prefilter_threshold
+        )
+        pia_prefiltered = pia_run_analysis(basename_to_pia_xmls, prefilter_analysis_json, pia_threads, pia_gb_ram, "mzid")
         prefiltered_pia_xmls = compile_pia_xmls(pia_prefiltered.psms, pia_threads, pia_gb_ram)
 
     emit:
@@ -153,16 +172,16 @@ process compile_pia_xmls {
     memory "${pia_gb_ram}.GB"
 
     input:
-    path identifications
+    tuple val(id_basename), path(identifications)      // mapping from the basename to the identifications
     val pia_threads
     val pia_gb_ram
 
     output:
-    path "${identifications.baseName}.pia.xml"
+    tuple val(id_basename), path("${id_basename}.pia.xml")
 
     script:
     """
-    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} --compile -o ${identifications.baseName}.pia.xml ${identifications}
+    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} --compile -o ${id_basename}.pia.xml ${identifications}
     """
 }
 
@@ -182,7 +201,7 @@ process prepare_analysis_json {
     val peptide_export
     val protein_export
     val fdr_filter
-    val remove_decoys       // remove decoys works only together with fdr_filer == true
+    val remove_decoys       // remove decoys works only together with fdr_filter == true
     val fdr_threshold
 
     output:
@@ -192,7 +211,7 @@ process prepare_analysis_json {
     """
     pia --example > pia_analysis.json
     
-    # delete the first row of the file
+    # delete the first row of the file, which contains en explanatory comment and does not start with the json
     sed -i 1d pia_analysis.json
 
     sed -i 's;"createPSMsets": .*,;"createPSMsets": false,;g' pia_analysis.json
@@ -265,31 +284,30 @@ process pia_run_analysis {
     memory "${pia_gb_ram}.GB"
 
     input:
-    path pia_xml
+    tuple val(search_basename), path(pia_xml)
     path pia_analysis_file
     val pia_threads
     val pia_gb_ram
-    val PSMformat           // needs to be changed between pre-processing (mzid9) and final (mzTab) 
+    val psm_export_format               // needs to be set correctly for pre-processing (mzid) and final (mzTab) 
 
     output:
-    path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.${PSMformat}", emit: psms
-    path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-peptides.csv", emit: peptides
-    path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-proteins.mzTab", emit: proteins
+    tuple val({search_basename}), path("psms.${psm_export_format}"), emit: psms
+    tuple val({search_basename}), path("peptides.csv"), emit: peptides
+    tuple val({search_basename}), path("proteins.mzTab"), emit: proteins
 
     script:
     """
-    filebase="${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}"
-    jsonfile="\${filebase}-analysis.json"
+    jsonfile="${search_basename}-analysis.json"
 
     cp ${pia_analysis_file} \${jsonfile}
 
-    touch \${filebase}-piaExport-PSM.${PSMformat}
-    touch \${filebase}-piaExport-peptides.csv
-    touch \${filebase}-piaExport-proteins.mzTab
+    touch psms.${psm_export_format}
+    touch peptides.csv
+    touch proteins.mzTab
 
-    sed -i 's;"psmExportFile": .*;"psmExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.${PSMformat}",;g' \${jsonfile}
-    sed -i 's;"peptideExportFile": .*;"peptideExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-peptides.csv",;g' \${jsonfile}
-    sed -i 's;"proteinExportFile": .*;"proteinExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-proteins.mzTab",;g' \${jsonfile}
+    sed -i 's;"psmExportFile": .*;"psmExportFile": "psms.${psm_export_format}",;g' \${jsonfile}
+    sed -i 's;"peptideExportFile": .*;"peptideExportFile": "peptides.csv",;g' \${jsonfile}
+    sed -i 's;"proteinExportFile": .*;"proteinExportFile": "proteins.mzTab",;g' \${jsonfile}
 
     pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} \${jsonfile} ${pia_xml}
     """
@@ -312,5 +330,33 @@ process pia_extract_csv {
     """
     outfile="${psm_results.name.take(psm_results.name.lastIndexOf('-piaExport-PSM.mzTab'))}-pia_extraction.hdf5"
     extract_from_pia_output.py --pia_PSMs ${psm_results} --pia_peptides ${peptide_results} --pia_proteins ${protein_results} --out_hdf5 \${outfile}
+    """
+}
+
+
+//
+// TODO: GET RID OF THIS PROCESS and implement the file and basenames correctly further downstream
+//
+process pia_rename_files_HOTFIX_CHANGE {
+    label 'mcquac_image'
+
+    cpus 1
+    memory "4.GB"
+
+    input:
+    tuple val(psms_basename), path(psms_result)
+    tuple val(peptides_basename), path(peptides_result)
+    tuple val(proteins_basename), path(proteins_result)
+
+    output:
+    path "${psms_basename}-piaExport-PSM.mzTab", emit: psms
+    path "${peptides_basename}-piaExport-peptides.csv", emit: peptides
+    path "${proteins_basename}-piaExport-proteins.mzTab", emit: proteins
+
+    script:
+    """
+    cp ${psms_result} ${psms_basename}-piaExport-PSM.mzTab
+    cp ${peptides_result} ${peptides_basename}-piaExport-peptides.csv
+    cp ${proteins_result} ${proteins_basename}-piaExport-proteins.mzTab
     """
 }

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -22,6 +22,7 @@ workflow pia_analysis {
         fdr_filter
         pia_threads
         pia_gb_ram
+        pia_fdr_threshold
         pia_prefilter_threshold
 
     main:
@@ -40,7 +41,7 @@ workflow pia_analysis {
 
         analysis_json = prepare_analysis_json(do_psm_export, do_peptide_export, do_protein_export, fdr_filter,
                 true,      // remove_decoys
-                0.01       // fdr_threshold, hardcoded to 1% for now
+                pia_fdr_threshold
         )
         pia_all_report_files = pia_run_analysis(basename_to_pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
 
@@ -68,6 +69,7 @@ workflow pia_analysis_full {
         identifications
         pia_threads
         pia_gb_ram
+        pia_fdr_threshold
         pia_prefilter_threshold
 
     main:
@@ -79,6 +81,7 @@ workflow pia_analysis_full {
             true,
             pia_threads,
             pia_gb_ram,
+            pia_fdr_threshold,
             pia_prefilter_threshold
         )
     
@@ -97,6 +100,7 @@ workflow pia_analysis_psm_only {
         fdr_filter
         pia_threads
         pia_gb_ram
+        pia_fdr_threshold
     
     main:
         pia_report_files = pia_analysis(
@@ -107,7 +111,8 @@ workflow pia_analysis_psm_only {
             fdr_filter,
             pia_threads,
             pia_gb_ram,
-            -1                  // <0 -> no pre-filtering here
+            pia_fdr_threshold,
+            0                           // 0 means no pre-filtering here
         )
 
     emit:

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -22,11 +22,18 @@ workflow pia_analysis {
         fdr_filter
         pia_threads
         pia_gb_ram
+        pia_prefilter_threshold
 
     main:
         pia_xmls = compile_pia_xmls(identifications, pia_threads, pia_gb_ram)
-        analysis_json = prepare_analysis_json(do_psm_export, do_peptide_export, do_protein_export, fdr_filter)
-        pia_all_report_files = pia_run_analysis(pia_xmls, analysis_json, pia_threads, pia_gb_ram)
+
+        if (pia_prefilter_threshold > 0) {
+            // perform the pre-filtering
+            pia_xmls = perform_pia_prefiltering(pia_xmls, pia_prefilter_threshold, pia_threads, pia_gb_ram)
+        }
+
+        analysis_json = prepare_analysis_json(do_psm_export, do_peptide_export, do_protein_export, fdr_filter, true, 0.01)
+        pia_all_report_files = pia_run_analysis(pia_xmls, analysis_json, pia_threads, pia_gb_ram, "mzTab")
 
         return_files = pia_all_report_files.psms.collect()
             .concat(pia_all_report_files.peptides.collect())
@@ -49,6 +56,7 @@ workflow pia_analysis_full {
         identifications
         pia_threads
         pia_gb_ram
+        pia_prefilter_threshold
 
     main:
         pia_report_files = pia_analysis(
@@ -58,7 +66,8 @@ workflow pia_analysis_full {
             true,
             true,
             pia_threads,
-            pia_gb_ram
+            pia_gb_ram,
+            pia_prefilter_threshold
         )
     
     emit:
@@ -85,7 +94,8 @@ workflow pia_analysis_psm_only {
             false,
             fdr_filter,
             pia_threads,
-            pia_gb_ram
+            pia_gb_ram,
+            -1
         )
 
     emit:
@@ -110,6 +120,24 @@ workflow pia_extract_metrics {
     
     emit:
         extract_csv
+}
+
+
+workflow perform_pia_prefiltering {
+    take:
+        pia_xmls
+        pia_prefilter_threshold
+        pia_threads
+        pia_gb_ram
+
+    main:
+        // perform the pre-filtering
+        prefilter_analysis_json = prepare_analysis_json(true, false, false, true, false, pia_prefilter_threshold)
+        pia_prefiltered = pia_run_analysis(pia_xmls, prefilter_analysis_json, pia_threads, pia_gb_ram, "mzid")
+        prefiltered_pia_xmls = compile_pia_xmls(pia_prefiltered.psms, pia_threads, pia_gb_ram)
+
+    emit:
+    prefiltered_pia_xmls
 }
 
 
@@ -154,6 +182,8 @@ process prepare_analysis_json {
     val peptide_export
     val protein_export
     val fdr_filter
+    val remove_decoys       // remove decoys works only together with fdr_filer == true
+    val fdr_threshold
 
     output:
     path "pia_analysis.json"
@@ -162,6 +192,7 @@ process prepare_analysis_json {
     """
     pia --example > pia_analysis.json
     
+    # delete the first row of the file
     sed -i 1d pia_analysis.json
 
     sed -i 's;"createPSMsets": .*,;"createPSMsets": false,;g' pia_analysis.json
@@ -200,9 +231,16 @@ process prepare_analysis_json {
 
     if [ ${fdr_filter} = true ];
     then
-      sed -i '/psmFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= 0.01",\\n    "psm_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
-      sed -i '/peptideFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= 0.01",\\n    "peptide_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
-      sed -i '/proteinFilters/{n;s/.*/    "protein_q_value_filter <= 0.01",\\n    "protein_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
+      if [ ${remove_decoys} = true ];
+      then
+        sed -i '/psmFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= ${fdr_threshold}",\\n    "psm_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
+        sed -i '/peptideFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= ${fdr_threshold}",\\n    "peptide_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
+        sed -i '/proteinFilters/{n;s/.*/    "protein_q_value_filter <= ${fdr_threshold}",\\n    "protein_accessions_filter !regex_only DECOY_.*"/g;}' pia_analysis.json
+      else
+        sed -i '/psmFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= ${fdr_threshold}"/g;}' pia_analysis.json
+        sed -i '/peptideFilters/{n;s/.*/    "psm_score_filter_psm_fdr_score <= ${fdr_threshold}"/g;}' pia_analysis.json
+        sed -i '/proteinFilters/{n;s/.*/    "protein_q_value_filter <= ${fdr_threshold}"/g;}' pia_analysis.json
+      fi
     else
       sed -i '/psmFilters/{n;s/.*//g;}' pia_analysis.json
       sed -i '/peptideFilters/{n;s/.*//g;}' pia_analysis.json
@@ -231,9 +269,10 @@ process pia_run_analysis {
     path pia_analysis_file
     val pia_threads
     val pia_gb_ram
+    val PSMformat           // needs to be changed between pre-processing (mzid9) and final (mzTab) 
 
     output:
-    path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.mzTab", emit: psms
+    path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.${PSMformat}", emit: psms
     path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-peptides.csv", emit: peptides
     path "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-proteins.mzTab", emit: proteins
 
@@ -244,11 +283,11 @@ process pia_run_analysis {
 
     cp ${pia_analysis_file} \${jsonfile}
 
-    touch \${filebase}-piaExport-PSM.mzTab
+    touch \${filebase}-piaExport-PSM.${PSMformat}
     touch \${filebase}-piaExport-peptides.csv
     touch \${filebase}-piaExport-proteins.mzTab
 
-    sed -i 's;"psmExportFile": .*;"psmExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.mzTab",;g' \${jsonfile}
+    sed -i 's;"psmExportFile": .*;"psmExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-PSM.${PSMformat}",;g' \${jsonfile}
     sed -i 's;"peptideExportFile": .*;"peptideExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-peptides.csv",;g' \${jsonfile}
     sed -i 's;"proteinExportFile": .*;"proteinExportFile": "${pia_xml.name.take(pia_xml.name.lastIndexOf('.pia.xml'))}-piaExport-proteins.mzTab",;g' \${jsonfile}
 

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -124,16 +124,23 @@ workflow pia_analysis_psm_only {
 }
 
 /**
- * Extracts the QC metrics from the PIA results and writes them into a HFD5
+ * Extracts the QC metrics from the PIA results and writes them into a HFD5.
+ * If peptides_table is true, the peptide tables will be saved to the results.
  *
  * @return extracted hdf5 metrics written into the HFD5 file
  */
 workflow pia_extract_metrics {
     take:
         pia_results
+        peptides_table
+        output_folder
 
     main:
         extract_csv = pia_extract_csv(pia_results)
+
+        if (peptides_table) {
+            save_peptide_files(pia_results, output_folder)
+        }   
     
     emit:
         extract_csv
@@ -336,6 +343,30 @@ process pia_extract_csv {
     """
     outfile="${psm_results.name.take(psm_results.name.lastIndexOf('-piaExport-PSM.mzTab'))}-pia_extraction.hdf5"
     extract_from_pia_output.py --pia_PSMs ${psm_results} --pia_peptides ${peptide_results} --pia_proteins ${protein_results} --out_hdf5 \${outfile}
+    """
+}
+
+
+process save_peptide_files {
+    label 'mcquac_image'
+
+    cpus 1
+    memory "1.GB"
+
+    publishDir path: { "${output_folder}" }, mode: 'move', overwrite: true
+
+    input:
+    tuple path(psm_results), path(peptide_results), path(protein_results)
+    val output_folder
+
+    output:
+    path "peptides/${peptide_results.name}"
+
+    script:
+    """
+    # create a symlink to save
+    mkdir peptides
+    cp ${peptide_results} peptides/${peptide_results.name}
     """
 }
 

--- a/src/pia.nf
+++ b/src/pia.nf
@@ -186,7 +186,7 @@ process compile_pia_xmls {
 
     script:
     """
-    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} --compile -o ${id_basename}.pia.xml ${identifications}
+    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} --compile -o '${id_basename}.pia.xml' '${identifications}'
     """
 }
 
@@ -315,7 +315,7 @@ process pia_run_analysis {
     sed -i 's;"peptideExportFile": .*;"peptideExportFile": "peptides.csv",;g' \${jsonfile}
     sed -i 's;"proteinExportFile": .*;"proteinExportFile": "proteins.mzTab",;g' \${jsonfile}
 
-    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} \${jsonfile} ${pia_xml}
+    pia -Xms2g -Xmx${pia_gb_ram}g --threads ${pia_threads} \${jsonfile} '${pia_xml}'
     """
 }
 


### PR DESCRIPTION
A pre-filtering step at the PSM level (<= 0.05 FDR by default) is now included.
This speeds up the analysis a lot, under most circumstances.

Please review, especially old numbers of PSMs, peptides and proteins.