### PR TITLE
patch vulnarable PR-comment artifact pattern

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -3,8 +3,11 @@ lint:
     - assets/multiqc_config.yml
     - conf/igenomes.config
     - conf/igenomes_ignored.config
+    - .github/workflows/linting_comment.yml
   files_unchanged:
     - assets/sendmail_template.txt
+    - .github/workflows/branch.yml
+    - .github/workflows/linting.yml
     - assets/nf-core-macproqc_logo_light.png
     - docs/images/nf-core-macproqc_logo_dark.png
     - docs/images/nf-core-macproqc_logo_light.png
@@ -13,8 +16,7 @@ nf_core_version: 4.1.0
 repository_type: pipeline
 template:
   author: Julian Uszkoreit, Dirk Winkelhardt, Karin Schork, Maike Weber, Dominik Lux
-  description: A workflow for the quality control of mass spectrometry-based proteomics
-    analyses
+  description: A workflow for the quality control of mass spectrometry-based proteomics analyses
   force: false
   is_nfcore: true
   name: macproqc


### PR DESCRIPTION
## Security patch


This PR applies a security fix included in nf-core/tools 4.0.3 for a potential exploit in the GitHub Actions workflows that post comments on pull requests.

For details, see the related security advisory: https://nf-co.re/advisories/pr-comment-workflow-vulnerability

The fix must be merged into the default branch to take effect. Please merge this PR as soon as possible.

These changes only affect CI workflows, so merging them into the default branch does not require a new pipeline release.